### PR TITLE
Fix 403 error in weekly and monthly report scripts

### DIFF
--- a/backend/Skripte/monthly_report.php
+++ b/backend/Skripte/monthly_report.php
@@ -1,4 +1,12 @@
 <?php
+// Spoof HTTP variables for CLI/Cron execution
+if (PHP_SAPI === 'cli' || empty($_SERVER['HTTP_ORIGIN'])) {
+    $_SERVER['HTTP_ORIGIN'] = 'https://ice-app.de';
+}
+if (!isset($_SERVER['REQUEST_METHOD'])) {
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+}
+
 require_once  __DIR__ . '/../db_connect.php';
 
 $empfaenger1 = 'ch_helbig@mail.de';
@@ -44,7 +52,7 @@ $checkinsNachAnreise = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // 5. Verteilung der Check-ins mit oder ohne Bild
 $stmt = $pdo->prepare(
-    "SELECT 
+    "SELECT
         CASE WHEN b.id IS NOT NULL THEN 'Mit Bild' ELSE 'Ohne Bild' END AS bild_status,
         COUNT(DISTINCT c.id) AS anzahl
     FROM checkins c

--- a/backend/Skripte/weekly_report.php
+++ b/backend/Skripte/weekly_report.php
@@ -1,4 +1,12 @@
 <?php
+// Spoof HTTP variables for CLI/Cron execution
+if (PHP_SAPI === 'cli' || empty($_SERVER['HTTP_ORIGIN'])) {
+    $_SERVER['HTTP_ORIGIN'] = 'https://ice-app.de';
+}
+if (!isset($_SERVER['REQUEST_METHOD'])) {
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+}
+
 require_once  __DIR__ . '/../db_connect.php';
 
 $empfaenger1 = 'ch_helbig@mail.de';
@@ -39,7 +47,7 @@ $stmt->execute(['start' => $startStr, 'ende' => $endeStr]);
 $checkinsNachAnreise = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // 5. Verteilung der Check-ins mit oder ohne Bild
-$stmt = $pdo->prepare("\n    SELECT 
+$stmt = $pdo->prepare("\n    SELECT
         CASE WHEN b.id IS NOT NULL THEN 'Mit Bild' ELSE 'Ohne Bild' END AS bild_status,
         COUNT(DISTINCT c.id) AS anzahl
     FROM checkins c


### PR DESCRIPTION
Added logic to spoof HTTP variables (`HTTP_ORIGIN` and `REQUEST_METHOD`) in `backend/Skripte/weekly_report.php` and `backend/Skripte/monthly_report.php` when executed via CLI or when origin is empty. This prevents `db_connect.php` from rejecting the request with a 403 Unauthorized error, resolving the issue with the cron jobs failing.

---
*PR created automatically by Jules for task [16503264970016186556](https://jules.google.com/task/16503264970016186556) started by @Trikolix*