### PR TITLE
Fix Summer Ice Champions award start month

### DIFF
--- a/backend/evaluators/IceSeasonEvaluator.php
+++ b/backend/evaluators/IceSeasonEvaluator.php
@@ -18,7 +18,7 @@ class IceSeasonEvaluator extends BaseAwardEvaluator {
         ],
         'summer' => [
             'award_id' => self::AWARD_ID_SUMMER,
-            'start_month' => 5,
+            'start_month' => 6,
             'start_day' => 1,
             'end_month' => 9,
             'end_day' => 1,

--- a/backend/evaluators/IceSummerEvaluator.php
+++ b/backend/evaluators/IceSummerEvaluator.php
@@ -49,7 +49,7 @@ class IceSummerEvaluator extends BaseAwardEvaluator {
 
         // Set the parameters
         $stmt->bindParam(':userId', $userId, PDO::PARAM_INT);
-        $startDate = "$year-05-01 00:00:00";
+        $startDate = "$year-06-01 00:00:00";
         $endDate = "$year-08-31 23:59:59";
         $stmt->bindParam(':startDate', $startDate);
         $stmt->bindParam(':endDate', $endDate);


### PR DESCRIPTION
Fixed an overlap in the check-in count for Ice Champions awards between Spring and Summer. Summer now counts from June (instead of May).

---
*PR created automatically by Jules for task [5181544566816588859](https://jules.google.com/task/5181544566816588859) started by @Trikolix*